### PR TITLE
@metamask/ethjs-rpc v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
-# 0.1.9 -- added promises
+# 0.3.0 -- maintenance update
+
+1. Renamed to `@metamask/ethjs-rpc`
+2. Fixed and removed broken devDependencies
+3. Require minimum nodejs v8.17, npm v6
+4. Repository location changed
+
+Internal:
+1. CI migrated from Travis to Github Actions
+2. `npm test-travis` is now `npm test:coverage`
+3. Removed coveralls
+
+# 0.2.0 -- added promises
 
 1. Fixed major callback / promise issue thanks to Kumavis!! (i.e. unhandled promise rejection swollowing errors)
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,6 @@
 ## ethjs-rpc
 
 <div>
-  <!-- Dependency Status -->
-  <a href="https://david-dm.org/ethjs/ethjs-rpc">
-    <img src="https://david-dm.org/ethjs/ethjs-rpc.svg"
-    alt="Dependency Status" />
-  </a>
-
-  <!-- devDependency Status -->
-  <a href="https://david-dm.org/ethjs/ethjs-rpc#info=devDependencies">
-    <img src="https://david-dm.org/ethjs/ethjs-rpc/dev-status.svg" alt="devDependency Status" />
-  </a>
-
   <!-- NPM Version -->
   <a href="https://www.npmjs.org/package/ethjs-rpc">
     <img src="http://img.shields.io/npm/v/ethjs-rpc.svg"
@@ -91,7 +80,7 @@ There is always a lot of work to do, and will have many rules to maintain. So pl
 
 Please consult our [Code of Conduct](CODE_OF_CONDUCT.md) docs before helping out.
 
-We communicate via [issues](https://github.com/ethjs/ethjs-rpc/issues) and [pull requests](https://github.com/ethjs/ethjs-rpc/pulls).
+We communicate via [issues](https://github.com/MetaMask/ethjs-rpc/issues) and [pull requests](https://github.com/ethjs/ethjs-rpc/pulls).
 
 ## Important documents
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ should not need to be touched.
 
 For more in-depth structure, see the developer-guide.md.
 
-*(If they do have to be changed, please [submit an issue](https://github.com/ethjs/ethjs-rpc/issues)!)*
+*(If they do have to be changed, please [submit an issue](https://github.com/MetaMask/ethjs-rpc/issues)!)*
 
 ### Testing
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -11,7 +11,7 @@ npm install --save ethjs-rpc
 ## Install from Source
 
 ```
-git clone http://github.com/ethjs/ethjs-rpc
+git clone http://github.com/MetaMask/ethjs-rpc
 npm install
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "ethjs-rpc",
-  "version": "0.2.0",
+  "name": "@metamask/ethjs-rpc",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ethjs-rpc",
-  "version": "0.2.0",
+  "name": "@metamask/ethjs-rpc",
+  "version": "0.3.0-rc1",
   "description": "A super simple module for querying the Ethereum RPC layer without formatting.",
   "main": "lib/index.js",
   "files": [
@@ -31,7 +31,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/ethjs/ethjs-rpc.git"
+    "url": "https://github.com/MetaMask/ethjs-rpc.git"
   },
   "keywords": [
     "ethereum",
@@ -46,9 +46,9 @@
   "author": "Nick Dodson <nick.dodson@consensys.net>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/ethjs/ethjs-rpc/issues"
+    "url": "https://github.com/MetaMask/ethjs-rpc/issues"
   },
-  "homepage": "https://github.com/ethjs/ethjs-rpc#readme",
+  "homepage": "https://github.com/MetaMask/ethjs-rpc#readme",
   "babel": {
     "plugins": [
       [


### PR DESCRIPTION
This is intended to be a safe maintenance release. It migrates CI to GHA and does the minimal changes to get install/build/test working again. Users of v0.2.0 should be able to upgrade safely.

* Bump version to v0.3.0
* Rename package to `@metamask/ethjs-rpc`
* Change repository URL to https://github.com/MetaMask/ethjs-rpc
* Update docs

### [v0.3.0 changes from v0.2.0](https://github.com/ethjs/ethjs-rpc/compare/master...legobt:ethjs-rpc:metamask-v0.3.0):

1. Renamed to `@metamask/ethjs-rpc`
2. Fixed and removed broken devDependencies (#3)
3. Require minimum nodejs v8.17, npm v6 (#5)
4. Repository location changed

Internal:
1. CI migrated from Travis to Github Actions (#2, #4)
2. `npm test-travis` is now `npm test:coverage` (#4)
3. Removed coveralls (#4)

