### PR TITLE
Update package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,10 @@
 ## ethjs-rpc
 
 <div>
-  <!-- Dependency Status -->
-  <a href="https://david-dm.org/ethjs/ethjs-rpc">
-    <img src="https://david-dm.org/ethjs/ethjs-rpc.svg"
-    alt="Dependency Status" />
-  </a>
-
-  <!-- devDependency Status -->
-  <a href="https://david-dm.org/ethjs/ethjs-rpc#info=devDependencies">
-    <img src="https://david-dm.org/ethjs/ethjs-rpc/dev-status.svg" alt="devDependency Status" />
-  </a>
-
   <!-- NPM Version -->
-  <a href="https://www.npmjs.org/package/ethjs-rpc">
-    <img src="http://img.shields.io/npm/v/ethjs-rpc.svg"
+  <a href="https://www.npmjs.org/package/@metamask/ethjs-rpc">
+    <img src="http://img.shields.io/npm/v/@metamask/ethjs-rpc.svg"
     alt="NPM version" />
-  </a>
-
-  <!-- Javascript Style -->
-  <a href="http://airbnb.io/javascript/">
-    <img src="https://img.shields.io/badge/code%20style-airbnb-brightgreen.svg" alt="js-airbnb-style" />
   </a>
 </div>
 
@@ -91,7 +75,7 @@ There is always a lot of work to do, and will have many rules to maintain. So pl
 
 Please consult our [Code of Conduct](CODE_OF_CONDUCT.md) docs before helping out.
 
-We communicate via [issues](https://github.com/ethjs/ethjs-rpc/issues) and [pull requests](https://github.com/ethjs/ethjs-rpc/pulls).
+We communicate via [issues](https://github.com/MetaMask/ethjs-rpc/issues) and [pull requests](https://github.com/MetaMask/ethjs-rpc/pulls).
 
 ## Important documents
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ should not need to be touched.
 
 For more in-depth structure, see the developer-guide.md.
 
-*(If they do have to be changed, please [submit an issue](https://github.com/ethjs/ethjs-rpc/issues)!)*
+*(If they do have to be changed, please [submit an issue](https://github.com/MetaMask/ethjs-rpc/issues)!)*
 
 ### Testing
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -11,7 +11,7 @@ npm install --save ethjs-rpc
 ## Install from Source
 
 ```
-git clone http://github.com/ethjs/ethjs-rpc
+git clone http://github.com/MetaMask/ethjs-rpc
 npm install
 ```
 

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
   "author": "Nick Dodson <nick.dodson@consensys.net>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/ethjs/ethjs-rpc/issues"
+    "url": "https://github.com/MetaMask/ethjs-rpc/issues"
   },
-  "homepage": "https://github.com/ethjs/ethjs-rpc#readme",
+  "homepage": "https://github.com/MetaMask/ethjs-rpc#readme",
   "babel": {
     "plugins": [
       [

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   "scripts": {
     "start": "npm test",
     "release": "npmpub",
-    "pretest": "npm run lint",
-    "prepublish": "npm run build",
     "prebuild": "npm run build:clean && npm run test",
+    "prepare": "npm run build",
+    "pretest": "npm run lint",
     "build:clean": "npm run test:clean && rimraf ./dist",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib --copy-files",
     "build:umd": "cross-env BABEL_ENV=commonjs NODE_ENV=development webpack --config ./internals/webpack/webpack.config.js ./lib/index.js --progress",


### PR DESCRIPTION
- Complete rename from `ethjs-rpc` to `@metamask/ethjs-rpc`
  - Change repo links to https://github.com/MetaMask/ethjs-rpc
- npm v5+ compat: rename `prepublish` script to `prepare`