### PR TITLE
devDeps: @metamask/ethjs-provider-http@^0.2.0->^0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -681,9 +681,9 @@
       }
     },
     "@metamask/ethjs-provider-http": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@metamask/ethjs-provider-http/-/ethjs-provider-http-0.2.0.tgz",
-      "integrity": "sha512-th0bsA+9z/xGKCGLtnZAlt/ReYB8m9YL9bUW8eAZ+qhrrsJnMvlMDLLBcA95mCVhBYNI9VMMYQNCRC1YMg0tUA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@metamask/ethjs-provider-http/-/ethjs-provider-http-0.3.0.tgz",
+      "integrity": "sha512-t4dHYDSXMJZc46SwTgbcXYWs4uzb311dzHe730ZKR0BiPbos8oc9+toMw43w+ziqymhAdIbYIXo3hXX3dw7tOw==",
       "dev": true,
       "requires": {
         "xhr2": "0.2.1"

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "@babel/plugin-transform-property-literals": "^7.0.0",
     "@babel/plugin-transform-object-rest-spread": "^7.0.0",
     "@babel/register": "^7.0.0",
-    "@metamask/ethjs-provider-http": "^0.2.0",
+    "@metamask/ethjs-provider-http": "^0.3.0",
     "babel-loader": "^8.0.0",
     "bignumber.js": "^9.1.2",
     "chai": "^4.4.1",


### PR DESCRIPTION
- Bump devDependency `@metamask/ethjs-provider-http` to latest. 
  - [Changelog](https://github.com/MetaMask/ethjs-provider-http/blob/main/CHANGELOG.md)
  - [Release](https://github.com/MetaMask/ethjs-provider-http/releases/tag/v0.3.0)